### PR TITLE
Add SwiftUI view modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ AudioEditorKit.presentEditor(audio: rep, parent: self) { edited, newURL in
 
 Additionally, you can specify export options by using the `exportAudioSettings` property of `AudioFileRepresentable`.
 
+For SwiftUI developers, use one of the view modifiers showing below:
+
+```swift
+ContentView()
+    .audioEditorSheet(
+        isPresented: $isPresented,
+        audio: rep
+    ) { edited, newURL in 
+        if edited {
+            // Handle the edited audio file at newURL
+        } 
+    }
+    .audioEditorFullScreenCover(
+        isPresented: $isPresented,
+        audio: rep
+    ) { edited, newURL in 
+        if edited {
+            // Handle the edited audio file at newURL
+        } 
+    }
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/Sources/AudioEditorKit/SwiftUI/AudioEditorSheet.swift
+++ b/Sources/AudioEditorKit/SwiftUI/AudioEditorSheet.swift
@@ -1,0 +1,67 @@
+//
+//  AudioEditorSheet.swift
+//  AudioEditorKit
+//
+//  Created by Yanan Li on 2025/5/1.
+//
+
+import SwiftUI
+
+extension View {
+    @available(iOS 16.0, macCatalyst 16.0, visionOS 1.0, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    nonisolated public func audioEditorSheet(
+        isPresented: Binding<Bool>,
+        audio: AudioFileRepresentable,
+        onAudioChanged: @escaping AudioClipController.AudioEditorCompletionHandler,
+        onDismiss: (() -> Void)? = nil
+    ) -> some View {
+        sheet(isPresented: isPresented, onDismiss: onDismiss) {
+            AudioEditor(audio: audio, completion: onAudioChanged)
+        }
+    }
+    
+    @available(iOS 16.0, macCatalyst 16.0, visionOS 1.0, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    nonisolated public func audioEditorFullScreenCover(
+        isPresented: Binding<Bool>,
+        audio: AudioFileRepresentable,
+        onAudioChanged: @escaping AudioClipController.AudioEditorCompletionHandler,
+        onDismiss: (() -> Void)? = nil
+    ) -> some View {
+        fullScreenCover(isPresented: isPresented, onDismiss: onDismiss) {
+            AudioEditor(audio: audio, completion: onAudioChanged)
+        }
+    }
+}
+
+// MARK: - Auxiliary
+
+private struct AudioEditor: UIViewControllerRepresentable {
+    var audio: AudioFileRepresentable
+    var completion: AudioClipController.AudioEditorCompletionHandler
+    
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let isPad = UIDevice.current.userInterfaceIdiom == .pad
+        let storyboard = UIStoryboard(
+            name: isPad ? "AudioClipController_iPad" : "AudioClipController",
+            bundle: AudioClipControllerBundle.bundle
+        )
+        let navController = storyboard.instantiateInitialViewController() as! UINavigationController
+        navController.modalPresentationStyle = .formSheet
+        navController.modalTransitionStyle = .coverVertical
+        navController.preferredContentSize = CGSize(width: 666, height: 666)
+        
+        return navController
+    }
+    
+    func updateUIViewController(_ controller: UINavigationController, context: Context) {
+        let controller = controller.viewControllers.first as! AudioClipController
+        controller.audio = audio
+        controller.completionHandler = completion
+    }
+}


### PR DESCRIPTION
I added 2 view modifiers for SwiftUI developers to quickly leverage this package.

- [x] Update README
- [x] Implement SwiftUI view controller representable & modifiers

### Screenshots
<img width="1728" alt="截屏2025-05-01 20 49 24" src="https://github.com/user-attachments/assets/c9e2f3ee-fd6f-4f3c-ae00-410c94fd808f" />
<img width="1728" alt="截屏2025-05-01 20 49 46" src="https://github.com/user-attachments/assets/4f6b15b4-d03b-4054-81e1-902d6a8d69ad" />
